### PR TITLE
Fix position model attr type

### DIFF
--- a/app/controllers/positions_controller.rb
+++ b/app/controllers/positions_controller.rb
@@ -23,7 +23,7 @@ class PositionsController < ApplicationController
 
   def position_params
     params.require(:position).permit(:title, :industry, :salary_from,
-                                     :salary_to, :position_type,
-                                     :description)
+                                     :salary_to, :office_hours,
+                                     :hiring_scheme, :description)
   end
 end

--- a/app/decorators/selection_process_decorator.rb
+++ b/app/decorators/selection_process_decorator.rb
@@ -3,20 +3,37 @@ class SelectionProcessDecorator < Draper::Decorator
   include Draper::LazyHelpers
 
   def contract_resume
-    content_tag(:p, class: 'mb-0') do
-      'Regime de contratação: ' +
-        I18n.t('activerecord.attributes.position.position_type.' +
-        position.position_type)
-    end +
-      content_tag(:p, class: 'mb-0') do
-        "Salário: #{number_to_currency(position.salary_from)}"\
-          " à #{number_to_currency(position.salary_to)}"
-      end
+    p_print_hiring_scheme + p_print_office_hours + p_print_salary
   end
 
   def logo_process
     link_to image_tag(company_profile.logo,
                       class: 'avatar-process float-left mr-2'),
             company_path(company)
+  end
+
+  private
+
+  def p_print_hiring_scheme
+    content_tag(:p, class: 'mb-0') do
+      'Regime de contratação: ' +
+        I18n.t('activerecord.attributes.position.hiring_scheme.' +
+        position.hiring_scheme)
+    end
+  end
+
+  def p_print_office_hours
+    content_tag(:p, class: 'mb-0') do
+      'Horário de expediente: ' +
+        I18n.t('activerecord.attributes.position.office_hours.' +
+        position.office_hours)
+    end
+  end
+
+  def p_print_salary
+    content_tag(:p, class: 'mb-0') do
+      "Salário: #{number_to_currency(position.salary_from)}"\
+        " à #{number_to_currency(position.salary_to)}"
+    end
   end
 end

--- a/app/models/position.rb
+++ b/app/models/position.rb
@@ -3,9 +3,9 @@ class Position < ApplicationRecord
   belongs_to :company
   has_many :invites, dependent: :nullify
 
-  enum position_type: { full_time: 0, part_time: 10, internship: 30,
-                        contractor: 40 }
+  enum hiring_scheme: { clt: 0, contractor: 5, internship: 10 }
+  enum office_hours: { full_time: 0, part_time: 10 }
 
   validates :title, :industry, :description, :salary_from, :salary_to,
-            :position_type, presence: true
+            :hiring_scheme, :office_hours, presence: true
 end

--- a/app/views/candidates/_invite.html.erb
+++ b/app/views/candidates/_invite.html.erb
@@ -14,10 +14,11 @@
         <p><span>Faixa salarial:</span> <%= number_to_currency invite.position.salary_from %>-<%= number_to_currency invite.position.salary_to %> </p>
         <p><span>Área de atuação:</span> <%=invite.position.industry %></p>
         <p><span>Descrição do cargo:</span> <%=invite.position.description%></p>
-        <p><span>Regime de Contratação:</span> <%= t(:"position_type.#{invite.position.position_type}") %></p>
+        <p><span>Regime de contratação:</span> <%= t("activerecord.attributes.position.hiring_scheme.#{invite.position.hiring_scheme}") %></p>
+        <p><span>Horário de expediente:</span> <%= t("activerecord.attributes.position.office_hours.#{invite.position.office_hours}") %></p>
       </div>
       <div class="col-md-3 d-flex align-items-end flex-wrap align-content-end">
-        <%= invite.invite_links %>      
+        <%= invite.invite_links %>
       </div>
     </div>
   </section>

--- a/app/views/positions/new.html.erb
+++ b/app/views/positions/new.html.erb
@@ -34,8 +34,13 @@
         </div>
 
         <div class="col">
-          <%= f.label :position_type, 'Tipo' %>
-          <%= f.select :position_type, Position.position_types.map { |k, v| [ I18n.t(:"position_type.#{k}"), k] }, {}, class: "form-control"  %>
+          <%= f.label :hiring_scheme, 'Regime' %>
+          <%= f.select :hiring_scheme, Position.hiring_schemes.map { |k, v| [ I18n.t("activerecord.attributes.position.hiring_scheme.#{k}"), k] }, class: "form-control" %>
+        </div>
+
+        <div class="col">
+          <%= f.label :office_hours, 'Expediente' %>
+          <%= f.select :office_hours, Position.office_hours.map { |k, v| [ I18n.t("activerecord.attributes.position.office_hours.#{k}"), k] }, class: "form-control" %>
         </div>
       </div>
       <%= f.submit 'Enviar', class: "mt-2 form-control btn btn-primary" %>

--- a/config/locales/models.pt-BR.yml
+++ b/config/locales/models.pt-BR.yml
@@ -14,11 +14,6 @@ pt-BR:
       company:
         name: Nome
         address: Endereço
-  # Humanização de keys dos Enums
-  position_type:
-    full_time: CLT
-    part_time: Meio Período
-    internship: Estágio
-    contractor: PJ
+
 
 

--- a/config/locales/position.pt-BR.yml
+++ b/config/locales/position.pt-BR.yml
@@ -8,10 +8,12 @@ pt-BR:
         title: Título
         industry: Área
         description: Descrição
-        position_type:
+        hiring_scheme:
+          internship: Estágio
+          contractor: PJ
+          clt: CLT
+        office_hours:
           full_time: Integral
           part_time: Meio Período
-          internship: Estágio
-          contractor: Contratante
         salary_from: Salário de
         salary_to: Salário até

--- a/db/migrate/20191024134429_remove_position_type_from_position.rb
+++ b/db/migrate/20191024134429_remove_position_type_from_position.rb
@@ -1,0 +1,6 @@
+class RemovePositionTypeFromPosition < ActiveRecord::Migration[6.0]
+  def change
+
+    remove_column :positions, :position_type, :integer
+  end
+end

--- a/db/migrate/20191024134507_add_office_hours_to_position.rb
+++ b/db/migrate/20191024134507_add_office_hours_to_position.rb
@@ -1,0 +1,5 @@
+class AddOfficeHoursToPosition < ActiveRecord::Migration[6.0]
+  def change
+    add_column :positions, :office_hours, :integer
+  end
+end

--- a/db/migrate/20191024134534_add_hiring_scheme_to_position.rb
+++ b/db/migrate/20191024134534_add_hiring_scheme_to_position.rb
@@ -1,0 +1,5 @@
+class AddHiringSchemeToPosition < ActiveRecord::Migration[6.0]
+  def change
+    add_column :positions, :hiring_scheme, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_22_194112) do
+ActiveRecord::Schema.define(version: 2019_10_24_134534) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -155,12 +155,13 @@ ActiveRecord::Schema.define(version: 2019_10_22_194112) do
     t.string "title"
     t.string "industry"
     t.text "description"
-    t.integer "position_type"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "company_id"
     t.integer "salary_from"
     t.integer "salary_to"
+    t.integer "office_hours"
+    t.integer "hiring_scheme"
     t.index ["company_id"], name: "index_positions_on_company_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -36,7 +36,8 @@ Employee.create!(email: "joao.silva@revelo.com.br",
 
 company.positions.create!(title: 'Desenvolvedor', industry: 'Tecnologia',
                  description: 'Desenvolvedor fullstack em Ruby',
-                 salary_from: 2000.00, salary_to: 3000.00, position_type: 'full_time')
+                 salary_from: 2000.00, salary_to: 3000.00, hiring_scheme: :clt,
+                 office_hours: :full_time)
 
 Invite.create!(candidate: Candidate.last, position: Position.last,
                status: :accepted)

--- a/spec/decorators/selection_process_decorator_spec.rb
+++ b/spec/decorators/selection_process_decorator_spec.rb
@@ -5,11 +5,11 @@ RSpec.describe SelectionProcessDecorator do
     it 'show resume of invite contract' do
       selection_process = create(:selection_process).decorate
 
-      expect(selection_process.contract_resume).to eq '<p class="mb-0">Regime'\
-                                                      ' de contratação: Integr'\
-                                                      'al</p><p class="mb-0">S'\
-                                                      'alário: R$ 4.500,00 à R'\
-                                                      '$ 5.500,00</p>'
+      expect(selection_process.contract_resume).to(
+        eq '<p class="mb-0">Regime de contratação: CLT</p><p '\
+           'class="mb-0">Horário de expediente: Integral</p><p '\
+           'class="mb-0">Salário: R$ 4.500,00 à R$ 5.500,00</p>'
+      )
     end
   end
 end

--- a/spec/factories/positions.rb
+++ b/spec/factories/positions.rb
@@ -5,7 +5,8 @@ FactoryBot.define do
     description { 'Desenvolvedor Ruby' }
     salary_from { 4500 }
     salary_to { 5500 }
-    position_type { :full_time }
+    office_hours { :full_time }
+    hiring_scheme { :clt }
     company
   end
 end

--- a/spec/features/candidate/candidate_sees_pending_invites_spec.rb
+++ b/spec/features/candidate/candidate_sees_pending_invites_spec.rb
@@ -24,6 +24,7 @@ feature 'candidate sees pending invites' do
     expect(page).to have_content invite.position.industry
     expect(page).to have_content invite.position.description
     expect(page).to have_content 'CLT'
+    expect(page).to have_content 'Integral'
   end
 
   scenario 'and accept invite successfully' do

--- a/spec/features/candidate/candidate_send_message_spec.rb
+++ b/spec/features/candidate/candidate_send_message_spec.rb
@@ -1,44 +1,68 @@
 require 'rails_helper'
 
-feature 'candidate send message' do
-  scenario 'successfully' do
-    candidate = create(:candidate, status: :published)
-    create(:candidate_profile, candidate: candidate)
-    position = create(:position)
-    position.company.company_profile = create(:company_profile)
-    create(:invite, candidate: candidate, position: position, status: :pending)
+feature 'candidate messages exchanges' do
+  context 'send message' do
+    scenario 'successfully' do
+      candidate = create(:candidate, status: :published)
+      create(:candidate_profile, candidate: candidate)
+      position = create(:position)
+      position.company.company_profile = create(:company_profile)
+      create(:invite, candidate: candidate, position: position, status: :pending)
+  
+      login_as(candidate, scope: :candidate)
+      visit root_path
+      click_on 'Convites'
+  
+      click_link('Aceitar')
+  
+      fill_in 'Escreva a sua mensagem', with: 'Olá, meu nome é João'
+      click_on('Enviar')
+  
+      expect(page).to have_css('h5', text: candidate.email)
+      expect(page).to have_content('Olá, meu nome é João')
+    end
 
-    login_as(candidate, scope: :candidate)
-    visit root_path
-    click_on 'Convites'
-
-    click_link('Aceitar')
-
-    fill_in 'Escreva a sua mensagem', with: 'Olá, meu nome é João'
-    click_on('Enviar')
-
-    expect(page).to have_css('h5', text: candidate.email)
-    expect(page).to have_content('Olá, meu nome é João')
+    scenario 'and validate empty field' do
+      candidate = create(:candidate, status: :published)
+      create(:candidate_profile, candidate: candidate)
+      position = create(:position, title: 'Desenvolvedor')
+      position.company.company_profile = create(:company_profile)
+      invite = create(:invite, candidate: candidate,
+                               position: position, status: :accepted)
+      invite.create_selection_process
+  
+      login_as(candidate, scope: :candidate)
+      visit root_path
+      click_on 'Convites'
+      click_on 'Ver convite'
+  
+      fill_in 'Escreva a sua mensagem', with: ''
+      click_on('Enviar')
+  
+      expect(page).to have_content('Não foi possivel enviar mensagem.'\
+                                   ' Tente novamente')
+    end
   end
 
-  scenario 'and validate empty field' do
-    candidate = create(:candidate, status: :published)
-    create(:candidate_profile, candidate: candidate)
-    position = create(:position, title: 'Desenvolvedor')
-    position.company.company_profile = create(:company_profile)
-    invite = create(:invite, candidate: candidate,
-                             position: position, status: :accepted)
-    invite.create_selection_process
-
-    login_as(candidate, scope: :candidate)
-    visit root_path
-    click_on 'Convites'
-    click_on 'Ver convite'
-
-    fill_in 'Escreva a sua mensagem', with: ''
-    click_on('Enviar')
-
-    expect(page).to have_content('Não foi possivel enviar mensagem.'\
-                                 ' Tente novamente')
+  context 'see company details' do
+    scenario 'with main employee' do
+      candidate = create(:candidate, status: :published)
+      create(:candidate_profile, candidate: candidate)
+      position = create(:position)
+      position.company.company_profile = create(:company_profile)
+      create(:invite, candidate: candidate, position: position, status: :pending)
+  
+      login_as(candidate, scope: :candidate)
+      visit root_path
+      click_on 'Convites'
+  
+      click_link('Aceitar')
+  
+      fill_in 'Escreva a sua mensagem', with: 'Olá, meu nome é João'
+      click_on('Enviar')
+  
+      expect(page).to have_css('h5', text: candidate.email)
+      expect(page).to have_content('Olá, meu nome é João')
+    end
   end
 end

--- a/spec/features/candidate/candidate_send_message_spec.rb
+++ b/spec/features/candidate/candidate_send_message_spec.rb
@@ -7,17 +7,20 @@ feature 'candidate messages exchanges' do
       create(:candidate_profile, candidate: candidate)
       position = create(:position)
       position.company.company_profile = create(:company_profile)
-      create(:invite, candidate: candidate, position: position, status: :pending)
-  
+      create(:invite,
+             candidate: candidate,
+             position: position,
+             status: :pending)
+
       login_as(candidate, scope: :candidate)
       visit root_path
       click_on 'Convites'
-  
+
       click_link('Aceitar')
-  
+
       fill_in 'Escreva a sua mensagem', with: 'Olá, meu nome é João'
       click_on('Enviar')
-  
+
       expect(page).to have_css('h5', text: candidate.email)
       expect(page).to have_content('Olá, meu nome é João')
     end
@@ -30,15 +33,15 @@ feature 'candidate messages exchanges' do
       invite = create(:invite, candidate: candidate,
                                position: position, status: :accepted)
       invite.create_selection_process
-  
+
       login_as(candidate, scope: :candidate)
       visit root_path
       click_on 'Convites'
       click_on 'Ver convite'
-  
+
       fill_in 'Escreva a sua mensagem', with: ''
       click_on('Enviar')
-  
+
       expect(page).to have_content('Não foi possivel enviar mensagem.'\
                                    ' Tente novamente')
     end
@@ -50,17 +53,20 @@ feature 'candidate messages exchanges' do
       create(:candidate_profile, candidate: candidate)
       position = create(:position)
       position.company.company_profile = create(:company_profile)
-      create(:invite, candidate: candidate, position: position, status: :pending)
-  
+      create(:invite,
+             candidate: candidate,
+             position: position,
+             status: :pending)
+
       login_as(candidate, scope: :candidate)
       visit root_path
       click_on 'Convites'
-  
+
       click_link('Aceitar')
-  
+
       fill_in 'Escreva a sua mensagem', with: 'Olá, meu nome é João'
       click_on('Enviar')
-  
+
       expect(page).to have_css('h5', text: candidate.email)
       expect(page).to have_content('Olá, meu nome é João')
     end

--- a/spec/features/employee/employee_creates_position_spec.rb
+++ b/spec/features/employee/employee_creates_position_spec.rb
@@ -13,7 +13,8 @@ feature 'Employee creates position' do
     fill_in 'Área', with: 'Desenvolvimento'
     fill_in 'Descrição', with: 'Posição que exige conhecimentos em HTTP, CSS, '\
                                'JavaScript e Ruby on Rails'
-    select 'CLT', from: 'Tipo'
+    select 'CLT', from: 'Regime'
+    select 'Integral', from: 'Expediente'
     fill_in 'De:', with: '2000'
     fill_in 'Até:', with: '4000'
     click_on 'Enviar'


### PR DESCRIPTION
Percebemos que o model de Position continha um atributo 'position_type' que misturava conceitos de regime (ex: clt, pj) com horário de expediente (ex: integral, meio período). 

A pior causa desse problema eram os textos sem sentido gerados que mostravam esse campo na view (ex: 'Regime de contratação: Integral')

Nesse PR o campo position_type foi removido e substituído office_hours (horário de expediente) 
 e hiring_scheme (regime de contratação). 