### PR TITLE
Candidate accept interview

### DIFF
--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -3,12 +3,14 @@ class InterviewsController < ApplicationController
   before_action :authenticate_candidate!, only: %i[accept reject]
 
   def accept
-    @interview.scheduled!
+    return unless @interview.pending? && @interview.scheduled!
+
     redirect_to selection_process_candidates_path(@interview.selection_process)
   end
 
   def reject
-    @interview.canceled!
+    return unless @interview.pending? && @interview.canceled!
+
     redirect_to selection_process_candidates_path(@interview.selection_process)
   end
 

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,0 +1,17 @@
+class InterviewsController < ApplicationController
+  before_action :set_interview, only: %i[accept reject]
+
+  def accept
+    @interview.scheduled!
+  end
+
+  def reject
+    @interview.canceled!
+  end
+
+  private
+
+  def set_interview
+    @interview = Interview.find(params[:id])
+  end
+end

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,12 +1,15 @@
 class InterviewsController < ApplicationController
   before_action :set_interview, only: %i[accept reject]
+  before_action :authenticate_candidate!, only: %i[accept reject]
 
   def accept
     @interview.scheduled!
+    redirect_to selection_process_candidates_path(@interview.selection_process)
   end
 
   def reject
     @interview.canceled!
+    redirect_to selection_process_candidates_path(@interview.selection_process)
   end
 
   private

--- a/app/controllers/selection_processes_controller.rb
+++ b/app/controllers/selection_processes_controller.rb
@@ -18,7 +18,9 @@ class SelectionProcessesController < ApplicationController
   private
 
   def decorate_interview
-    @interviews = InterviewDecorator.decorate(@selection_process.interviews)
+    @interviews = InterviewDecorator.decorate_collection(
+      @selection_process.interviews
+    )
   end
 
   def set_selection_process

--- a/app/controllers/selection_processes_controller.rb
+++ b/app/controllers/selection_processes_controller.rb
@@ -1,5 +1,6 @@
 class SelectionProcessesController < ApplicationController
   before_action :set_selection_process, only: %i[show send_message]
+  before_action :decorate_interview, only: %i[show]
 
   def show; end
 
@@ -15,6 +16,10 @@ class SelectionProcessesController < ApplicationController
   end
 
   private
+
+  def decorate_interview
+    @interviews = InterviewDecorator.decorate(@selection_process.interviews)
+  end
 
   def set_selection_process
     @selection_process = SelectionProcess.find(params[:id])

--- a/app/controllers/selection_processes_controller.rb
+++ b/app/controllers/selection_processes_controller.rb
@@ -3,9 +3,7 @@ class SelectionProcessesController < ApplicationController
   before_action :authenticate_users!, only: %i[show send_message]
   before_action :decorate_interview, only: %i[show]
 
-  def show
-    @pending_interviews = @interviews.where(status: :pending)
-  end
+  def show; end
 
   def send_message
     message = @selection_process.messages.create(params.permit(:text)) do |m|

--- a/app/controllers/selection_processes_controller.rb
+++ b/app/controllers/selection_processes_controller.rb
@@ -3,7 +3,9 @@ class SelectionProcessesController < ApplicationController
   before_action :authenticate_users!, only: %i[show send_message]
   before_action :decorate_interview, only: %i[show]
 
-  def show; end
+  def show
+    @pending_interviews = @interviews.where(status: :pending)
+  end
 
   def send_message
     message = @selection_process.messages.create(params.permit(:text)) do |m|

--- a/app/decorators/interview_decorator.rb
+++ b/app/decorators/interview_decorator.rb
@@ -3,13 +3,8 @@ class InterviewDecorator < Draper::Decorator
 
   delegate_all
 
-  # Define presentation-specific methods here. Helpers are accessed through
-  # `helpers` (aka `h`). You can override attributes, for example:
-  #
-  #   def created_at
-  #     helpers.content_tag :span, class: 'time' do
-  #       object.created_at.strftime("%a %m/%d/%y")
-  #     end
-  #   end
-
+  def format_datetime
+    'Dia ' + interview.datetime.strftime('%d/%m/%Y') +
+      ' às ' + interview.datetime.strftime('%R')
+  end
 end

--- a/app/decorators/interview_decorator.rb
+++ b/app/decorators/interview_decorator.rb
@@ -4,8 +4,9 @@ class InterviewDecorator < Draper::Decorator
   delegate_all
 
   def format_datetime
-    'Dia ' + interview.datetime.strftime('%d/%m/%Y') +
-      ' às ' + interview.datetime.strftime('%R')
+    date = interview.datetime.strftime('%d/%m/%Y')
+    time = interview.datetime.strftime('%R')
+    I18n.t('activerecord.attributes.interview.datetime', date: date, time: time)
   end
 
   def decision_buttons
@@ -16,11 +17,14 @@ class InterviewDecorator < Draper::Decorator
 
   def interview_status_badge
     if interview.pending?
-      content_tag(:span, 'Aguardando resposta', class: 'badge badge-warning')
+      content_tag(:span, I18n.t('status_badge.pending'),
+                  class: 'badge badge-warning')
     elsif interview.scheduled?
-      content_tag(:span, 'Entrevista agendada', class: 'badge badge-primary')
+      content_tag(:span, I18n.t('status_badge.scheduled'),
+                  class: 'badge badge-primary')
     elsif interview.canceled?
-      content_tag(:span, 'Entrevista cancelada', class: 'badge badge-danger')
+      content_tag(:span, I18n.t('status_badge.rejected'),
+                  class: 'badge badge-danger')
     end
   end
 

--- a/app/decorators/interview_decorator.rb
+++ b/app/decorators/interview_decorator.rb
@@ -7,4 +7,32 @@ class InterviewDecorator < Draper::Decorator
     'Dia ' + interview.datetime.strftime('%d/%m/%Y') +
       ' às ' + interview.datetime.strftime('%R')
   end
+
+  def decision_buttons
+    return '' unless interview.pending?
+
+    reject_button + accept_button
+  end
+
+  def interview_status_badge
+    if interview.pending?
+      content_tag(:span, 'Aguardando resposta', class: 'badge badge-warning')
+    elsif interview.scheduled?
+      content_tag(:span, 'Entrevista agendada', class: 'badge badge-primary')
+    elsif interview.canceled?
+      content_tag(:span, 'Entrevista cancelada', class: 'badge badge-danger')
+    end
+  end
+
+  private
+
+  def accept_button
+    link_to 'Aceitar', accept_interview_candidate_path(interview),
+            class: 'btn btn-outline-success', method: :post
+  end
+
+  def reject_button
+    link_to 'Recusar', reject_interview_candidate_path(interview),
+            class: 'btn btn-outline-danger', method: :post
+  end
 end

--- a/app/decorators/interview_decorator.rb
+++ b/app/decorators/interview_decorator.rb
@@ -1,0 +1,15 @@
+class InterviewDecorator < Draper::Decorator
+  include Draper::LazyHelpers
+
+  delegate_all
+
+  # Define presentation-specific methods here. Helpers are accessed through
+  # `helpers` (aka `h`). You can override attributes, for example:
+  #
+  #   def created_at
+  #     helpers.content_tag :span, class: 'time' do
+  #       object.created_at.strftime("%a %m/%d/%y")
+  #     end
+  #   end
+
+end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -1,3 +1,5 @@
 class Interview < ApplicationRecord
   belongs_to :selection_process
+
+  enum status: { pending: 0, scheduled: 5, done: 10, absent: 15, canceled: 20 }
 end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -2,4 +2,5 @@ class Interview < ApplicationRecord
   belongs_to :selection_process
 
   enum status: { pending: 0, scheduled: 5, done: 10, absent: 15, canceled: 20 }
+  enum format: { online: 0, face_to_face: 10 }
 end

--- a/app/views/interviews/_interview_invite.html.erb
+++ b/app/views/interviews/_interview_invite.html.erb
@@ -1,10 +1,11 @@
 <div class="border-top p-3">
-  <p><b><%= interview.format_datetime %></b></p>
-  <address>Endereço: <%= interview.address %></address>
-  <p>Formato: <%= interview.format %></p>
-  <p>Status: <%= interview.status %></p>
+  <%= interview.interview_status_badge%>
+  <p>
+    <b><%= interview.format_datetime %></b><br/>
+    Endereço: <%= interview.address %><br/>
+    Formato: <%= I18n.t('format.'+interview.format) %><br/>
+  </p>
   <section class="row d-flex justify-content-around">
-    <%= link_to 'Recusar', reject_interview_candidate_path(interview), class: 'btn btn-danger', method: :post %>
-    <%= link_to 'Aceitar', accept_interview_candidate_path(interview), class: 'btn btn-success', method: :post %>
+  <%= interview.decision_buttons %>
   </section>
 </div>

--- a/app/views/interviews/_interview_invite.html.erb
+++ b/app/views/interviews/_interview_invite.html.erb
@@ -3,7 +3,7 @@
   <p>Dia <%= interview.datetime %></p>
   <p><%= interview.format %></p>
   <address>Endereço: <%= interview.address %></address>
-  <section class="row">
+  <section class="row d-flex justify-content-around">
     <%= link_to 'Aceitar', root_path, class: 'btn btn-danger' %>
     <%= link_to 'Rejeitar', root_path, class: 'btn btn-success' %>
   </section>

--- a/app/views/interviews/_interview_invite.html.erb
+++ b/app/views/interviews/_interview_invite.html.erb
@@ -1,10 +1,9 @@
-<div class="card p-2">
-  <header>Você tem um novo convite para entrevista</header>
-  <p>Dia <%= interview.datetime %></p>
-  <p><%= interview.format %></p>
+<div class="border-top p-2">
+  <p><%= interview.format_datetime %></p>
   <address>Endereço: <%= interview.address %></address>
+  <p>Formato: <%= interview.format %></p>
   <section class="row d-flex justify-content-around">
-    <%= link_to 'Recusar', root_path, class: 'btn btn-danger' %>
-    <%= link_to 'Aceitar', root_path, class: 'btn btn-success' %>
+    <%= link_to 'Recusar', reject_invites_candidate_path(interview), class: 'btn btn-danger', method: :post %>
+    <%= link_to 'Aceitar', accept_invites_candidate_path(interview), class: 'btn btn-success', method: :post %>
   </section>
 </div>

--- a/app/views/interviews/_interview_invite.html.erb
+++ b/app/views/interviews/_interview_invite.html.erb
@@ -1,0 +1,10 @@
+<div class="card p-2">
+  <header>Você tem um novo convite para entrevista</header>
+  <p>Dia <%= interview.datetime %></p>
+  <p><%= interview.format %></p>
+  <address>Endereço: <%= interview.address %></address>
+  <section class="row">
+    <%= link_to 'Aceitar', root_path, class: 'btn btn-danger' %>
+    <%= link_to 'Rejeitar', root_path, class: 'btn btn-success' %>
+  </section>
+</div>

--- a/app/views/interviews/_interview_invite.html.erb
+++ b/app/views/interviews/_interview_invite.html.erb
@@ -1,9 +1,10 @@
-<div class="border-top p-2">
-  <p><%= interview.format_datetime %></p>
+<div class="border-top p-3">
+  <p><b><%= interview.format_datetime %></b></p>
   <address>Endereço: <%= interview.address %></address>
   <p>Formato: <%= interview.format %></p>
+  <p>Status: <%= interview.status %></p>
   <section class="row d-flex justify-content-around">
-    <%= link_to 'Recusar', reject_invites_candidate_path(interview), class: 'btn btn-danger', method: :post %>
-    <%= link_to 'Aceitar', accept_invites_candidate_path(interview), class: 'btn btn-success', method: :post %>
+    <%= link_to 'Recusar', reject_interview_candidate_path(interview), class: 'btn btn-danger', method: :post %>
+    <%= link_to 'Aceitar', accept_interview_candidate_path(interview), class: 'btn btn-success', method: :post %>
   </section>
 </div>

--- a/app/views/interviews/_interview_invite.html.erb
+++ b/app/views/interviews/_interview_invite.html.erb
@@ -4,7 +4,7 @@
   <p><%= interview.format %></p>
   <address>Endereço: <%= interview.address %></address>
   <section class="row d-flex justify-content-around">
-    <%= link_to 'Aceitar', root_path, class: 'btn btn-danger' %>
-    <%= link_to 'Rejeitar', root_path, class: 'btn btn-success' %>
+    <%= link_to 'Recusar', root_path, class: 'btn btn-danger' %>
+    <%= link_to 'Aceitar', root_path, class: 'btn btn-success' %>
   </section>
 </div>

--- a/app/views/selection_processes/_messages.html.erb
+++ b/app/views/selection_processes/_messages.html.erb
@@ -1,6 +1,4 @@
-<div class="col-12 col-md-10 offset-md-1 mb-2">
-  <div class="card card-body mb-0">
+  <div class="card card-body mb-2">
     <h5><%= message.sendable.email %></h5>
     <p class="mb-0"><%= message.text %></p>
   </div>
-</div> 

--- a/app/views/selection_processes/show.html.erb
+++ b/app/views/selection_processes/show.html.erb
@@ -1,6 +1,6 @@
 <div class="container-fluid">
   <div class="row">
-    <div class="col-8 offset-md-2">
+    <div class="col-8">
       <h1><%= @selection_process.company.name %></h1>
       <%= form_with(url: send_message_candidates_path(@selection_process), method: 'post') do |f| %>
         <div class="form-group">
@@ -22,11 +22,11 @@
         <% end %>
       </div>
     </div>
+    <section class="col-4">
+      <header>
+        <h4>Entrevistas</h4>
+      </header>
+      <%= render partial: '/interviews/interview_invite', collection: @interviews, as: :interview %>
+    </section>
   </div>
-  <section class='row'>
-    <header>
-      <h4>Entrevistas</h4>
-    </header>
-    <%= render partial: '/interviews/interview_invite', collection: @selection_process.interviews, as: :interview %>
-  </section>
 </div>

--- a/app/views/selection_processes/show.html.erb
+++ b/app/views/selection_processes/show.html.erb
@@ -1,7 +1,13 @@
-<div class="container-fluid">
+<div class="container-fluid bg-light">
+  <h1><%= @selection_process.company.name %></h1>
   <div class="row">
+    <section class="col-3 card px-0">
+    <header class="text-center p-1">
+      <h4>Entrevistas</h4>
+    </header>
+    <%= render partial: '/interviews/interview_invite', collection: @interviews, as: :interview %>
+  </section>
     <div class="col-8">
-      <h1><%= @selection_process.company.name %></h1>
       <%= form_with(url: send_message_candidates_path(@selection_process), method: 'post') do |f| %>
         <div class="form-group">
           <%= f.label :text, "Mensagem:" %>
@@ -22,11 +28,5 @@
         <% end %>
       </div>
     </div>
-    <section class="col-4">
-      <header>
-        <h4>Entrevistas</h4>
-      </header>
-      <%= render partial: '/interviews/interview_invite', collection: @interviews, as: :interview %>
-    </section>
   </div>
 </div>

--- a/app/views/selection_processes/show.html.erb
+++ b/app/views/selection_processes/show.html.erb
@@ -15,11 +15,11 @@
   </div>
   <div class="container-fluid px-5">
     <div class="row">
-      <section class="col-md-3 card align-self-start">
-        <header class="text-center p-1">
-          <h4>Entrevistas</h4>
+      <section class="col-md-3 card align-self-start px-0">
+        <header class="text-center">
+          <h3 class="my-2">Entrevistas</h3>
         </header>
-        <%= render partial: '/interviews/interview_invite', collection: @interviews, as: :interview %>
+        <%= render partial: '/interviews/interview_invite', collection: @pending_interviews, as: :interview %>
       </section>
       <div class="col-md-9 mb-5">
         <div class="card card-body">

--- a/app/views/selection_processes/show.html.erb
+++ b/app/views/selection_processes/show.html.erb
@@ -19,7 +19,7 @@
         <header class="text-center">
           <h3 class="my-2">Entrevistas</h3>
         </header>
-        <%= render partial: '/interviews/interview_invite', collection: @pending_interviews, as: :interview %>
+        <%= render partial: '/interviews/interview_invite', collection: @interviews, as: :interview %>
       </section>
       <div class="col-md-9 mb-5">
         <div class="card card-body">

--- a/app/views/selection_processes/show.html.erb
+++ b/app/views/selection_processes/show.html.erb
@@ -1,6 +1,6 @@
 <div class="container-fluid">
   <div class="row">
-    <div class="col-12 col-8 offset-md-2">
+    <div class="col-8 offset-md-2">
       <h1><%= @selection_process.company.name %></h1>
       <%= form_with(url: send_message_candidates_path(@selection_process), method: 'post') do |f| %>
         <div class="form-group">
@@ -23,4 +23,10 @@
       </div>
     </div>
   </div>
+  <section class='row'>
+    <header>
+      <h4>Entrevistas</h4>
+    </header>
+    <%= render partial: '/interviews/interview_invite', collection: @selection_process.interviews, as: :interview %>
+  </section>
 </div>

--- a/config/locales/interview.pt-BR.yml
+++ b/config/locales/interview.pt-BR.yml
@@ -6,12 +6,19 @@ pt-BR:
       interview:
         format: Formato
         address: Endereço
-  status:
-    pending: Pendente
-    scheduled: Agendada
-    done: Realizada
-    absent: Ausente
-    rejected: Cancelada
+        datetime: Dia %{date} às %{time}
+    status:
+      pending: Pendente
+      scheduled: Agendada
+      done: Realizada
+      absent: Ausente
+      rejected: Cancelada
+  status_badge:
+    pending: Aguardando resposta
+    scheduled: Entrevista agendada
+    done: Entrevista realizada
+    absent: Candidato faltou
+    rejected: Entrevista cancelada
   format:
     online: Online
     face_to_face: Presencial

--- a/config/locales/interview.pt-BR.yml
+++ b/config/locales/interview.pt-BR.yml
@@ -1,0 +1,17 @@
+pt-BR:
+  activerecord:
+    models:
+      interview: Entrevista
+    attributes:
+      interview:
+        format: Formato
+        address: Endereço
+  status:
+    pending: Pendente
+    scheduled: Agendada
+    done: Realizada
+    absent: Ausente
+    rejected: Cancelada
+  format:
+    online: Online
+    face_to_face: Presencial

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,8 @@ Rails.application.routes.draw do
     post 'invites/reject/:id', to: 'candidates#reject_invite', on: :member, as: :reject_invites
     get 'invites/select_process/:id', to: 'selection_processes#show', on: :collection, as: :selection_process
     post 'invites/select_process/:id', to: 'selection_processes#send_message', on: :collection, as: :send_message
+    post 'interviews/accept/:id', to: 'interviews#accept', on: :member, as: :accept_interview
+    post 'interviews/reject/:id', to: 'interviews#reject', on: :member, as: :reject_interview
   end
 
   resources :positions, only: %i[new create show]

--- a/db/migrate/20191024141803_add_status_to_interview.rb
+++ b/db/migrate/20191024141803_add_status_to_interview.rb
@@ -1,0 +1,5 @@
+class AddStatusToInterview < ActiveRecord::Migration[6.0]
+  def change
+    add_column :interviews, :status, :integer, default:'0'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_22_194112) do
+ActiveRecord::Schema.define(version: 2019_10_24_141803) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -128,6 +128,7 @@ ActiveRecord::Schema.define(version: 2019_10_22_194112) do
     t.integer "selection_process_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "status", default: 0
     t.index ["selection_process_id"], name: "index_interviews_on_selection_process_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -48,5 +48,11 @@ Message.create!(sendable: Employee.first, selection_process: selection_process,
                 text: 'Olá! Adoramos o seu perfil, '\
                       'podemos marcar uma entrevista?')
 
+
+Interview.create!(datetime: '2019-10-26 17:00:00', format: :face_to_face, address: 'Av. Paulista, 2000', selection_process: selection_process)
+Interview.create!(datetime: '2019-08-30 07:00:00', format: :online, address: 'skype', selection_process: selection_process, status: :scheduled)
+Interview.create!(datetime: '2019-07-26 12:34:56', format: :face_to_face, address: 'Av. Paulista, 2000', selection_process: selection_process, status: :canceled)
+Interview.create!(datetime: '2019-10-20 17:00:00', format: :online, address: 'skype', selection_process: selection_process)
+
 company.company_profile.logo.attach(io: File.open(Rails.root.join('spec', 'support', 'images', 'gatinho.jpg')), filename: "gatinho.jpg")
 

--- a/spec/decorators/interview_decorator_spec.rb
+++ b/spec/decorators/interview_decorator_spec.rb
@@ -1,4 +1,123 @@
 require 'rails_helper'
 
-RSpec.describe InterviewDecorator do
+describe InterviewDecorator do
+  context '#format_datetime' do
+    it 'shows datetime formated correctly' do
+      company = create(:company, name: 'Revelo', url_domain: 'revelo.com.br')
+      company.company_profile = create(:company_profile)
+      candidate = create(:candidate, status: :published)
+      create(:employee, email: 'joao@revelo.com.br', company: company)
+      position = create(:position, company: company)
+      invite = create(:invite, candidate: candidate, position: position,
+                               status: :pending)
+      selection_process = invite.create_selection_process
+      interview = create(:interview,
+                         datetime: '2019-10-26 17:00:00',
+                         format: :face_to_face,
+                         address: 'Av. Paulista, 2000',
+                         selection_process: selection_process).decorate
+
+      expect(interview.format_datetime).to eq 'Dia 26/10/2019 às 17:00'
+    end
+  end
+  context '#decision_buttons' do
+    it 'shows decision buttons if invite is pending' do
+      company = create(:company, name: 'Revelo', url_domain: 'revelo.com.br')
+      company.company_profile = create(:company_profile)
+      candidate = create(:candidate, status: :published)
+      create(:employee, email: 'joao@revelo.com.br', company: company)
+      position = create(:position, company: company)
+      invite = create(:invite, candidate: candidate, position: position,
+                               status: :pending)
+      selection_process = invite.create_selection_process
+      interview = create(:interview,
+                         datetime: '2019-10-26 17:00:00',
+                         format: :face_to_face,
+                         address: 'Av. Paulista, 2000',
+                         selection_process: selection_process,
+                         status: :pending).decorate
+
+      expect(interview.decision_buttons).to(include 'Aceitar')
+      expect(interview.decision_buttons).to(include 'Recusar')
+    end
+    it 'shows returns nothing buttons if invite is not pending' do
+      company = create(:company, name: 'Revelo', url_domain: 'revelo.com.br')
+      company.company_profile = create(:company_profile)
+      candidate = create(:candidate, status: :published)
+      create(:employee, email: 'joao@revelo.com.br', company: company)
+      position = create(:position, company: company)
+      invite = create(:invite, candidate: candidate, position: position,
+                               status: :pending)
+      selection_process = invite.create_selection_process
+      interview = create(:interview, datetime: '2019-10-26 17:00:00',
+                                     format: :face_to_face,
+                                     address: 'Av. Paulista, 2000',
+                                     selection_process: selection_process,
+                                     status: :scheduled).decorate
+
+      expect(interview.decision_buttons).to eq ''
+    end
+  end
+  context '#interview_status_badge' do
+    it 'shows pending_badge correctly' do
+      company = create(:company, name: 'Revelo', url_domain: 'revelo.com.br')
+      company.company_profile = create(:company_profile)
+      candidate = create(:candidate, status: :published)
+      create(:employee, email: 'joao@revelo.com.br', company: company)
+      position = create(:position, company: company)
+      invite = create(:invite, candidate: candidate, position: position,
+                               status: :pending)
+      selection_process = invite.create_selection_process
+      interview = create(:interview,
+                         datetime: '2019-10-26 17:00:00',
+                         format: :face_to_face,
+                         address: 'Av. Paulista, 2000',
+                         selection_process: selection_process,
+                         status: :pending).decorate
+
+      expect(interview.interview_status_badge).to(
+        include 'Aguardando resposta'
+      )
+    end
+    it 'shows scheduled_badge correctly' do
+      company = create(:company, name: 'Revelo', url_domain: 'revelo.com.br')
+      company.company_profile = create(:company_profile)
+      candidate = create(:candidate, status: :published)
+      create(:employee, email: 'joao@revelo.com.br', company: company)
+      position = create(:position, company: company)
+      invite = create(:invite, candidate: candidate, position: position,
+                               status: :pending)
+      selection_process = invite.create_selection_process
+      interview = create(:interview,
+                         datetime: '2019-10-26 17:00:00',
+                         format: :face_to_face,
+                         address: 'Av. Paulista, 2000',
+                         selection_process: selection_process,
+                         status: :scheduled).decorate
+
+      expect(interview.interview_status_badge).to(
+        include 'Entrevista agendada'
+      )
+    end
+    it 'shows canceled_badge correctly' do
+      company = create(:company, name: 'Revelo', url_domain: 'revelo.com.br')
+      company.company_profile = create(:company_profile)
+      candidate = create(:candidate, status: :published)
+      create(:employee, email: 'joao@revelo.com.br', company: company)
+      position = create(:position, company: company)
+      invite = create(:invite, candidate: candidate, position: position,
+                               status: :pending)
+      selection_process = invite.create_selection_process
+      interview = create(:interview,
+                         datetime: '2019-10-26 17:00:00',
+                         format: :face_to_face,
+                         address: 'Av. Paulista, 2000',
+                         selection_process: selection_process,
+                         status: :canceled).decorate
+
+      expect(interview.interview_status_badge).to(
+        include 'Entrevista cancelada'
+      )
+    end
+  end
 end

--- a/spec/decorators/interview_decorator_spec.rb
+++ b/spec/decorators/interview_decorator_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe InterviewDecorator do
+end

--- a/spec/features/interview/candidate_accept_interview_spec.rb
+++ b/spec/features/interview/candidate_accept_interview_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+feature 'candidate accept interview' do
+  scenario 'successfully' do
+    company = create(:company, name: 'Revelo', url_domain: 'revelo.com.br')
+    candidate = create(:candidate, status: :published)
+    create(:employee, email: 'joao@revelo.com.br', company: company)
+    position = create(:position, company: company)
+    invite = create(:invite, candidate: candidate, position: position,
+                             status: :pending)
+    selection_process = invite.create_selection_process
+    create(:interview, datetime: '2019-10-26 17:00:00',
+                       format: :face_to_face,
+                       address: 'Av. Paulista, 2000',
+                       selection_process: selection_process)
+
+    login_as(candidate, scope: :candidate)
+    visit selection_process_candidates_path(selection_process)
+
+    expect(page).to have_content('Você tem um novo convite para entrevista')
+    expect(page).to have_content('Dia 26/10/2019 às 17:00')
+    expect(page).to have_content('Local: Av. Paulista, 2000')
+    expect(page).to have_content('Formato: presencial')
+    expect(page).to have_button('Aceitar')
+    expect(page).to have_button('Rejeitar')
+  end
+end

--- a/spec/features/interview/candidate_accept_interview_spec.rb
+++ b/spec/features/interview/candidate_accept_interview_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'candidate accept interview' do
+feature 'candidate see interview invite' do
   scenario 'successfully' do
     company = create(:company, name: 'Revelo', url_domain: 'revelo.com.br')
     company.company_profile = create(:company_profile)
@@ -21,8 +21,55 @@ feature 'candidate accept interview' do
     expect(page).to have_content('Entrevistas')
     expect(page).to have_content('Dia 26/10/2019 às 17:00')
     expect(page).to have_content('Endereço: Av. Paulista, 2000')
-    expect(page).to have_content('Formato: presencial')
+    expect(page).to have_content('Formato: Presencial')
+    expect(page).to have_content('Aguardando resposta')
     expect(page).to have_link('Aceitar')
     expect(page).to have_link('Recusar')
+  end
+
+  scenario 'and accept' do
+    company = create(:company, name: 'Revelo', url_domain: 'revelo.com.br')
+    company.company_profile = create(:company_profile)
+    candidate = create(:candidate, status: :published)
+    create(:employee, email: 'joao@revelo.com.br', company: company)
+    position = create(:position, company: company)
+    invite = create(:invite, candidate: candidate, position: position,
+                             status: :pending)
+    selection_process = invite.create_selection_process
+    create(:interview, datetime: '2019-10-26 17:00:00',
+                       format: :face_to_face,
+                       address: 'Av. Paulista, 2000',
+                       selection_process: selection_process)
+
+    login_as(candidate, scope: :candidate)
+    visit selection_process_candidates_path(selection_process)
+    click_on 'Aceitar'
+
+    expect(page).to have_content('Entrevista agendada')
+    expect(page).not_to have_link('Aceitar')
+    expect(page).not_to have_link('Recusar')
+  end
+
+  scenario 'and reject' do
+    company = create(:company, name: 'Revelo', url_domain: 'revelo.com.br')
+    company.company_profile = create(:company_profile)
+    candidate = create(:candidate, status: :published)
+    create(:employee, email: 'joao@revelo.com.br', company: company)
+    position = create(:position, company: company)
+    invite = create(:invite, candidate: candidate, position: position,
+                             status: :pending)
+    selection_process = invite.create_selection_process
+    create(:interview, datetime: '2019-10-26 17:00:00',
+                       format: :face_to_face,
+                       address: 'Av. Paulista, 2000',
+                       selection_process: selection_process)
+
+    login_as(candidate, scope: :candidate)
+    visit selection_process_candidates_path(selection_process)
+    click_on 'Recusar'
+
+    expect(page).to have_content('Entrevista cancelada')
+    expect(page).not_to have_link('Aceitar')
+    expect(page).not_to have_link('Recusar')
   end
 end

--- a/spec/features/interview/candidate_accept_interview_spec.rb
+++ b/spec/features/interview/candidate_accept_interview_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 feature 'candidate accept interview' do
   scenario 'successfully' do
     company = create(:company, name: 'Revelo', url_domain: 'revelo.com.br')
+    company.company_profile = create(:company_profile)
     candidate = create(:candidate, status: :published)
     create(:employee, email: 'joao@revelo.com.br', company: company)
     position = create(:position, company: company)

--- a/spec/features/interview/candidate_accept_interview_spec.rb
+++ b/spec/features/interview/candidate_accept_interview_spec.rb
@@ -17,11 +17,11 @@ feature 'candidate accept interview' do
     login_as(candidate, scope: :candidate)
     visit selection_process_candidates_path(selection_process)
 
-    expect(page).to have_content('Você tem um novo convite para entrevista')
+    expect(page).to have_content('Entrevistas')
     expect(page).to have_content('Dia 26/10/2019 às 17:00')
-    expect(page).to have_content('Local: Av. Paulista, 2000')
+    expect(page).to have_content('Endereço: Av. Paulista, 2000')
     expect(page).to have_content('Formato: presencial')
-    expect(page).to have_button('Aceitar')
-    expect(page).to have_button('Recusar')
+    expect(page).to have_link('Aceitar')
+    expect(page).to have_link('Recusar')
   end
 end

--- a/spec/features/interview/candidate_accept_interview_spec.rb
+++ b/spec/features/interview/candidate_accept_interview_spec.rb
@@ -22,6 +22,6 @@ feature 'candidate accept interview' do
     expect(page).to have_content('Local: Av. Paulista, 2000')
     expect(page).to have_content('Formato: presencial')
     expect(page).to have_button('Aceitar')
-    expect(page).to have_button('Rejeitar')
+    expect(page).to have_button('Recusar')
   end
 end

--- a/spec/requests/interview/candidate_cannot_change_interview_status_twice_spec.rb
+++ b/spec/requests/interview/candidate_cannot_change_interview_status_twice_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+describe 'Interview' do
+  context 'accept' do
+    it 'candidate cannot accept rejected interview' do
+      company = create(:company, name: 'Revelo', url_domain: 'revelo.com.br')
+      company.company_profile = create(:company_profile)
+      candidate = create(:candidate, status: :published)
+      create(:employee, email: 'joao@revelo.com.br', company: company)
+      position = create(:position, company: company)
+      invite = create(:invite, candidate: candidate, position: position,
+                               status: :pending)
+      selection_process = invite.create_selection_process
+      interview = create(:interview, datetime: '2019-10-26 17:00:00',
+                                     format: :face_to_face,
+                                     address: 'Av. Paulista, 2000',
+                                     selection_process: selection_process,
+                                     status: :canceled)
+
+      login_as(candidate, scope: :candidate)
+      post accept_interview_candidate_path(interview)
+
+      interview.reload
+      expect(interview.status).to eq 'canceled'
+    end
+  end
+  context 'reject' do
+    it 'candidate cannot reject accepted interview' do
+      company = create(:company, name: 'Revelo', url_domain: 'revelo.com.br')
+      company.company_profile = create(:company_profile)
+      candidate = create(:candidate, status: :published)
+      create(:employee, email: 'joao@revelo.com.br', company: company)
+      position = create(:position, company: company)
+      invite = create(:invite, candidate: candidate, position: position,
+                               status: :pending)
+      selection_process = invite.create_selection_process
+      interview = create(:interview, datetime: '2019-10-26 17:00:00',
+                                     format: :face_to_face,
+                                     address: 'Av. Paulista, 2000',
+                                     selection_process: selection_process,
+                                     status: :scheduled)
+
+      login_as(candidate, scope: :candidate)
+      post reject_interview_candidate_path(interview)
+
+      interview.reload
+      expect(interview.status).to eq 'scheduled'
+    end
+  end
+end


### PR DESCRIPTION
Nessa task foi criada a opção do candidato poder aceitar ou recusar um convite de entrevista.
O convite é inicialmente criado como pendente e o candidato tem acesso a dois botões que mudam o status do convite para aceito ou recusado.
Foram adicionados os testes de:
- Visualização do convite
- Aceitação do convite
- Recusa do convite
- Visualização do convite com status alterado
- Request de post de mudança de status
- Unidade do decorator

O layout da tela de processo seletivo foi alterado para acomodar os convites para entrevista
![image](https://user-images.githubusercontent.com/17439541/67642500-20a1fa00-f8eb-11e9-9537-9240a68cf235.png)
