### PR TITLE
Candidates receives invite notification

### DIFF
--- a/app/controllers/candidates_controller.rb
+++ b/app/controllers/candidates_controller.rb
@@ -42,7 +42,7 @@ class CandidatesController < ApplicationController
   def invite
     invite = @candidate.invites.new(@invite_params)
     if invite.save
-      InviteMailer.notify_candidate(invite.id)
+      InviteMailer.notify_candidate(invite.id).deliver_now
       flash[:success] = "#{@candidate.name} convidado com sucesso para " \
       "#{@position.title}"
       redirect_to candidates_path

--- a/app/controllers/candidates_controller.rb
+++ b/app/controllers/candidates_controller.rb
@@ -42,6 +42,7 @@ class CandidatesController < ApplicationController
   def invite
     invite = @candidate.invites.new(@invite_params)
     if invite.save
+      InviteMailer.notify_candidate(invite.id)
       flash[:success] = "#{@candidate.name} convidado com sucesso para " \
       "#{@position.title}"
       redirect_to candidates_path

--- a/app/mailers/invite_mailer.rb
+++ b/app/mailers/invite_mailer.rb
@@ -1,0 +1,9 @@
+class InviteMailer < ApplicationMailer
+  def notify_candidate(invite_id)
+    @invite = Invite.find(invite_id)
+    @position = @invite.position
+    @company = @invite.position.company
+    mail(to: @invite.candidate.email, subject: "#{@invite.candidate.name}, "\
+      "você foi convidado para uma posição na #{@invite.position.company.name}")
+  end
+end

--- a/app/views/invite_mailer/notify_candidate.html.erb
+++ b/app/views/invite_mailer/notify_candidate.html.erb
@@ -1,4 +1,11 @@
 <h1><%= @company.name %> te convidou para a posição de <%= @position.title %>.</h1>
-<h4>Veja a descrição do cargo:</h4>
-<p><%= @position.description %></p>
+<p>
+  Olá <%=@invite.candidate.name%>, <br>
+  Estamos felizes de avisar que a empresa <%= @company.name %> te convidou para uma posição de <%= @position.title %>.<br>
+  Para ver mais detalhes sobre o convite clique abaixo:
+</p>
 <%= link_to 'Ver detalhes', invites_candidates_url %>
+
+Atenciosamente,
+
+Equipe Revelinho

--- a/app/views/invite_mailer/notify_candidate.html.erb
+++ b/app/views/invite_mailer/notify_candidate.html.erb
@@ -1,2 +1,4 @@
-<%= @company.name %> te convidou para a vaga de <%= @position.title %>
+<h1><%= @company.name %> te convidou para a posição de <%= @position.title %>.</h1>
+<h4>Veja a descrição do cargo:</h4>
+<p><%= @position.description %></p>
 <%= link_to 'Ver detalhes', invites_candidates_url %>

--- a/app/views/invite_mailer/notify_candidate.html.erb
+++ b/app/views/invite_mailer/notify_candidate.html.erb
@@ -1,0 +1,2 @@
+<%= @company.name %> te convidou para a vaga de <%= @position.title %>
+<%= link_to 'Ver detalhes', invites_candidates_url %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -5,7 +5,7 @@
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
-  
+
   config.cache_classes = false
 
   # Do not eager load code on boot. This avoids loading your whole application
@@ -45,4 +45,7 @@ Rails.application.configure do
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
+
+  # Default host for action mailer
+  config.action_mailer.default_url_options = { :host => "test.revelo.com.br"  }
 end

--- a/spec/features/invites/employee_invites_candidate_spec.rb
+++ b/spec/features/invites/employee_invites_candidate_spec.rb
@@ -9,10 +9,9 @@ feature 'Invites' do
     create(:candidate_profile, candidate: candidate)
     create(:position, title: 'Engenheiro de Software Pleno',
                       company: company)
-    mailer_spy = class_spy('InviteMailer')
-    stub_const('InviteMailer', mailer_spy)
-    mail = double('mail', deliver_now: nil)
-    allow(mailer_spy).to receive(:notify_candidate).and_return(mail)
+    mail = double
+    allow(InviteMailer).to receive(:notify_candidate).and_return(mail)
+    allow(mail).to receive(:deliver_now)
 
     login_as(employee, scope: :employee)
     visit candidate_path(candidate)
@@ -25,7 +24,7 @@ feature 'Invites' do
     candidate.reload
 
     invite_id = candidate.invites.last.id
-    expect(mailer_spy).to have_received(:notify_candidate).with(invite_id)
+    expect(InviteMailer).to have_received(:notify_candidate).with(invite_id)
     expect(page).to have_content('Gustavo convidado com sucesso para ' \
     'Engenheiro de Software Pleno')
     expect(candidate.invites.count).to eq(1)

--- a/spec/features/invites/employee_invites_candidate_spec.rb
+++ b/spec/features/invites/employee_invites_candidate_spec.rb
@@ -9,6 +9,12 @@ feature 'Invites' do
     create(:candidate_profile, candidate: candidate)
     create(:position, title: 'Engenheiro de Software Pleno',
                       company: company)
+                      
+    mailer_spy = class_spy('InviteMailer')
+    stub_const('InviteMailer', mailer_spy)
+    mail = double
+    allow(mailer_spy).to receive(:notify_candidate).and_return(mail)
+    allow(mail).to receive(:deliver_now).and_return(nil)
 
     login_as(employee, scope: :employee)
     visit candidate_path(candidate)
@@ -19,6 +25,8 @@ feature 'Invites' do
     click_on 'Convidar'
 
     candidate.reload
+    invite_id = candidate.invites.last.id
+    expect(mailer_spy).to have_received(:notify_candidate).with(invite_id)
     expect(page).to have_content('Gustavo convidado com sucesso para ' \
     'Engenheiro de Software Pleno')
     expect(candidate.invites.count).to eq(1)

--- a/spec/features/invites/employee_invites_candidate_spec.rb
+++ b/spec/features/invites/employee_invites_candidate_spec.rb
@@ -9,12 +9,10 @@ feature 'Invites' do
     create(:candidate_profile, candidate: candidate)
     create(:position, title: 'Engenheiro de Software Pleno',
                       company: company)
-                      
     mailer_spy = class_spy('InviteMailer')
     stub_const('InviteMailer', mailer_spy)
-    mail = double
+    mail = double('mail', deliver_now: nil)
     allow(mailer_spy).to receive(:notify_candidate).and_return(mail)
-    allow(mail).to receive(:deliver_now).and_return(nil)
 
     login_as(employee, scope: :employee)
     visit candidate_path(candidate)
@@ -25,6 +23,7 @@ feature 'Invites' do
     click_on 'Convidar'
 
     candidate.reload
+
     invite_id = candidate.invites.last.id
     expect(mailer_spy).to have_received(:notify_candidate).with(invite_id)
     expect(page).to have_content('Gustavo convidado com sucesso para ' \

--- a/spec/mailers/invite_mailer_spec.rb
+++ b/spec/mailers/invite_mailer_spec.rb
@@ -60,7 +60,7 @@ describe InviteMailer do
       )
 
       mail = InviteMailer.notify_candidate(invite.id)
-      expect(mail.body).to include 'Revelo te convidou para a vaga de ' \
+      expect(mail.body).to include 'Revelo te convidou para a posição de ' \
                                    'Engenheiro de Software Pleno'
       expect(mail.body).to include invites_candidates_url
     end

--- a/spec/mailers/invite_mailer_spec.rb
+++ b/spec/mailers/invite_mailer_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+describe InviteMailer do
+  describe '#notify_candidate' do
+    it 'should send with proper subject' do
+      company = create(:company, name: 'Revelo', url_domain: 'revelo.com.br')
+      create(:employee, email: 'renata@revelo.com.br', company: company)
+      candidate = create(:candidate, name: 'Gustavo',
+                                     email: 'gustavo@email.com')
+      create(:candidate_profile, candidate: candidate)
+      position = create(:position, title: 'Engenheiro de Software Pleno',
+                                   company: company)
+      invite = create(
+        :invite,
+        candidate: candidate,
+        position: position,
+        message: 'Olá, ser humano. Venha fazer parte do nosso time'
+      )
+
+      mail = InviteMailer.notify_candidate(invite.id)
+      expect(mail.subject).to eq 'Gustavo, você foi convidado ' \
+                                 'para uma posição na Revelo'
+    end
+
+    it 'should send to candidate email' do
+      company = create(:company, name: 'Revelo',
+                                 url_domain: 'revelo.com.br')
+      create(:employee, email: 'renata@revelo.com.br',
+                        company: company)
+      candidate = create(:candidate, name: 'Gustavo',
+                                     email: 'gustavo@email.com')
+      create(:candidate_profile, candidate: candidate)
+      position = create(:position, title: 'Engenheiro de Software Pleno',
+                                   company: company)
+      invite = create(
+        :invite,
+        candidate: candidate,
+        position: position,
+        message: 'Olá, ser humano. Venha fazer parte do nosso time'
+      )
+
+      mail = InviteMailer.notify_candidate(invite.id)
+      expect(mail.to).to include 'gustavo@email.com'
+    end
+
+    it 'should have an invitation message' do
+      company = create(:company, name: 'Revelo', url_domain: 'revelo.com.br')
+      create(:employee, email: 'renata@revelo.com.br',
+                        company: company)
+      candidate = create(:candidate, name: 'Gustavo',
+                                     email: 'gustavo@email.com')
+      create(:candidate_profile, candidate: candidate)
+      position = create(:position, title: 'Engenheiro de Software Pleno',
+                                   company: company)
+      invite = create(
+        :invite,
+        candidate: candidate,
+        position: position,
+        message: 'Olá, ser humano. Venha fazer parte do nosso time'
+      )
+
+      mail = InviteMailer.notify_candidate(invite.id)
+      expect(mail.body).to include 'Revelo te convidou para a vaga de ' \
+                                   'Engenheiro de Software Pleno'
+      expect(mail.body).to include invites_candidates_url
+    end
+  end
+end


### PR DESCRIPTION
Os candidatos agora receberão um email toda vez que um funcionário convidá-lo para uma posição.

Esse email conterá uma notificação informando a empresa que enviou a posição, o título da mesma e um link que redireciona para uma página contendo mais detalhes.