### PR TITLE
fix schedule interview button been viewed by candidate

### DIFF
--- a/app/decorators/selection_process_decorator.rb
+++ b/app/decorators/selection_process_decorator.rb
@@ -41,8 +41,13 @@ class SelectionProcessDecorator < Draper::Decorator
   end
 
   def btn_schedule_interview
-    link_to 'Agendar nova entrevista', new_selection_process_interview_path(id),
-            class: 'btn btn-outline-info btn-sm mb-3'
+    if employee_signed_in?
+      link_to 'Agendar nova entrevista',
+              new_selection_process_interview_path(id),
+              class: 'btn btn-outline-info btn-sm mb-3'
+    else
+      ''
+    end
   end
 
   private

--- a/spec/system/selection_processes/candidate_sees_selection_processes_spec.rb
+++ b/spec/system/selection_processes/candidate_sees_selection_processes_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+feature 'Selection processes' do
+  scenario 'Candidate sees invites count in dashboard page' do
+    company = create(:company, url_domain: 'revelo.com.br')
+    create(:company_profile, company: company)
+    create(:employee, email: 'renata@revelo.com.br',
+                      company: company)
+    candidate = create(:candidate)
+    create(:candidate_profile, candidate: candidate)
+    position = create(:position, title: 'Engenheiro de Software Pleno',
+                                 company: company)
+    invite = create(:invite, :accepted, position: position,
+                                        candidate: candidate)
+
+    create(:selection_process, invite: invite)
+
+    login_as(candidate, scope: :candidate)
+    visit root_path
+
+    within '#invites-card' do
+      expect(page).to have_content(1)
+    end
+  end
+
+  scenario 'Candidate sees a selection process from selection processes page' do
+    company = create(:company, url_domain: 'revelo.com.br')
+    create(:company_profile, company: company)
+    create(:employee, email: 'renata@revelo.com.br',
+                      company: company)
+    candidate = create(:candidate)
+    create(:candidate_profile, candidate: candidate)
+    position = create(:position, title: 'Engenheiro de Software Pleno',
+                                 company: company)
+    invite = create(:invite, :accepted, position: position,
+                                        candidate: candidate)
+
+    create(:selection_process, invite: invite)
+
+    login_as(candidate, scope: :candidate)
+    visit root_path
+    click_on 'Convites'
+    click_on 'Ver convite'
+
+    expect(page).not_to have_content('Agendar nova entrevista')
+    expect(page).not_to have_content('Quero contratá-lo')
+  end
+end


### PR DESCRIPTION
**Bug**: botão de agendar entrevista presente na tela de processo seletivo estava visível para um candidato logado.
**Correção**: Botão de agendar entrevista agora só é visualisado por um funcionário logado.
Inclusão de testes para garantir que o problema não ocorra novamente.