### PR TITLE
fixed back button

### DIFF
--- a/app/views/companies/show.html.erb
+++ b/app/views/companies/show.html.erb
@@ -84,7 +84,7 @@
   <% end %>
 
     <div class="row justify-content-center mr-3">
-        <%= link_to t('messages.go_back'), :back, class: 'btn btn-outline-primary' %>
+        <%= link_to t('messages.go_back'), dashboard_companies_path, class: 'btn btn-outline-primary' %>
     </div>
 
 </div>


### PR DESCRIPTION
O botão de voltar do show da company estava voltando para o edit do company_profile quando você chegava na página depois de editá-lo. Agora está fixado para o dashboard da company